### PR TITLE
calloc: initialize memory correctly with zero

### DIFF
--- a/src/malloc/malloc.c
+++ b/src/malloc/malloc.c
@@ -359,8 +359,6 @@ void *calloc(size_t m, size_t n)
 	void *p = malloc(n);
 	if (!p) return p;
 	if (!__malloc_replaced) {
-		if (IS_MMAPPED(MEM_TO_CHUNK(p)))
-			return p;
 		if (n >= PAGE_SIZE)
 			n = mal0_clear(p, PAGE_SIZE, n);
 	}


### PR DESCRIPTION
In dc84c0a0 an optimization was introduced to avoid zeroing out pages
in some cases. However due to an update of musl __malloc0 is gone
and the check if memory was allocated via mmap was moved to calloc.
This commit removes this check to unconditionally zero out memory again.