### PR TITLE
Changes from enclave_util.h being split apart

### DIFF
--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -21,6 +21,7 @@
 #include "libc.h"
 #include "dynlink.h"
 #include "malloc_impl.h"
+#include "enclave/enclave_util.h"
 #include "enclave/sgxlkl_app_config.h"
 #include <sys/prctl.h>
 

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -9,6 +9,7 @@
 #include "syscall.h"
 #include "enclave/sgxlkl_config.h"
 #include "enclave/lthread.h"
+#include "enclave/enclave_util.h"
 
 static int spawned_ethreads = 1;
 

--- a/src/internal/syscall.h
+++ b/src/internal/syscall.h
@@ -16,7 +16,7 @@
 
 #include "enclave/sgxlkl_t.h"
 #include "enclave/enclave_mem.h"
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 
 #ifndef SYSCALL_RLIM_INFINITY
 #define SYSCALL_RLIM_INFINITY (~0ULL)

--- a/src/misc/syscall.c
+++ b/src/misc/syscall.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 
 #include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 
 #undef syscall
 


### PR DESCRIPTION
This changes is needed as part of work addressing sgx-lkl #151.
enclave_util.h was split into two parts:

enclave/enclave_util.h
lkl/lkl_util.h