### PR TITLE
Move lthread changes out

### DIFF
--- a/arch/x86_64/pthread_arch.h
+++ b/arch/x86_64/pthread_arch.h
@@ -1,7 +1,7 @@
-static inline struct schedctx *__scheduler_self()
+static inline struct pthread *__pthread_self()
 {
-	struct schedctx *self;
-	__asm__ __volatile__ ("mov %%fs:48,%0" : "=r" (self) );
+	struct pthread *self;
+	__asm__ ("mov %%fs:0,%0" : "=r" (self) );
 	return self;
 }
 

--- a/include/alltypes.h.in
+++ b/include/alltypes.h.in
@@ -47,7 +47,7 @@ TYPEDEF unsigned useconds_t;
 #ifdef __cplusplus
 TYPEDEF unsigned long pthread_t;
 #else
-TYPEDEF struct lthread * pthread_t;
+TYPEDEF struct __pthread * pthread_t;
 #endif
 TYPEDEF int pthread_once_t;
 TYPEDEF unsigned pthread_key_t;

--- a/include/elf.h
+++ b/include/elf.h
@@ -1038,6 +1038,8 @@ typedef struct {
 
 #define AT_MINSIGSTKSZ		51
 
+// SGX-LKL specific entries
+#define AT_HW_MODE 100 // a_val == 1 if sgx-lkl running in hw mode
 
 typedef struct {
   Elf32_Word n_namesz;

--- a/include/threads.h
+++ b/include/threads.h
@@ -8,7 +8,7 @@
 extern "C" {
 typedef unsigned long thrd_t;
 #else
-typedef struct lthread *thrd_t;
+typedef struct __pthread *thrd_t;
 #define thread_local _Thread_local
 #endif
 

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -106,7 +106,7 @@ struct symdef {
 
 static struct builtin_tls {
 	char c;
-        struct pthread pt;
+    struct pthread pt;
 	void *space[16];
 } builtin_tls[1];
 #define MIN_TLS_ALIGN offsetof(struct builtin_tls, pt)
@@ -1937,8 +1937,6 @@ void __dls3(elf64_stack_t *stack, void *tos)
 	 * copy relocations which depend on libraries' relocations. */
 	reloc_all(app.next);
 	reloc_all(&app);
-
-	// __init_utls(&app.tls);
 
 	update_tls_size();
 	//if (libc.tls_size > sizeof builtin_tls || tls_align > MIN_TLS_ALIGN) {

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -106,7 +106,7 @@ struct symdef {
 
 static struct builtin_tls {
 	char c;
-    struct pthread pt;
+	struct pthread pt;
 	void *space[16];
 } builtin_tls[1];
 #define MIN_TLS_ALIGN offsetof(struct builtin_tls, pt)

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -1676,9 +1676,8 @@ if (!sgxlkl_in_sw_debug_mode()) {
 		fprintf(stderr, "[    SGX-LKL   ] Warning: The application requires thread-local storage (TLS), but the current system configuration does not allow SGX-LKL to provide full TLS support in hardware mode. See sgx-lkl-run-oe --help-tls for more information.\n");
 		fsgsbase_warn = 1;
 	}
-}
 	libc.tls_cnt = tls_cnt;
-	libc.tls_align = 16; //tls_align;
+	libc.tls_align = tls_align;
 	libc.tls_size = ALIGN(
 		(1+tls_cnt) * sizeof(void *) +
 		tls_offset +
@@ -1939,6 +1938,10 @@ void __dls3(elf64_stack_t *stack, void *tos)
 	reloc_all(&app);
 
 	update_tls_size();
+	// We have set tls_align to 16 in update_tls_size(), this will cause the if
+	// branch to always evaluate to true.
+	// Which is what we want(for now), as the else logic makes assumptions that the
+	// execution of the earlier stages of the linker happened in the same thread.
 	//if (libc.tls_size > sizeof builtin_tls || tls_align > MIN_TLS_ALIGN) {
 		void *initial_tls = calloc(libc.tls_size, 1);
 		if (!initial_tls) {

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -1938,9 +1938,7 @@ void __dls3(elf64_stack_t *stack, void *tos)
 	reloc_all(&app);
 
 	update_tls_size();
-	// We have set tls_align to 16 in update_tls_size(), this will cause the if
-	// branch to always evaluate to true.
-	// Which is what we want(for now), as the else logic makes assumptions that the
+	// The else logic is commented because it makes assumptions that the
 	// execution of the earlier stages of the linker happened in the same thread.
 	//if (libc.tls_size > sizeof builtin_tls || tls_align > MIN_TLS_ALIGN) {
 		void *initial_tls = calloc(libc.tls_size, 1);

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -1770,11 +1770,11 @@ void *__dls2b(size_t *sp)
 	/* Setup early thread pointer in builtin_tls for ldso/libc itself to
 	 * use during dynamic linking. If possible it will also serve as the
 	 * thread pointer at runtime. */
-	// libc.tls_size = sizeof builtin_tls;
-	// libc.tls_align = tls_align;
-	// if (__init_tp(__copy_tls((void *)builtin_tls)) < 0) {
-	// 	a_crash();
-	// }
+	libc.tls_size = sizeof builtin_tls;
+	libc.tls_align = tls_align;
+	if (__init_tp(__copy_tls((void *)builtin_tls)) < 0) {
+		a_crash();
+	}
 
 	// We don't call __dls3 here. Once we've got here, we're safe enough to
 	// init LKL, after which we can then run stage 3.

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -1678,13 +1678,13 @@ if (!sgxlkl_in_sw_debug_mode()) {
 	}
 }
 	libc.tls_cnt = tls_cnt;
-	libc.tls_align = tls_align;
+	libc.tls_align = 16; //tls_align;
 	libc.tls_size = ALIGN(
 		(1+tls_cnt) * sizeof(void *) +
 		tls_offset +
 		sizeof(struct pthread) +
-		tls_align * 2,
-	tls_align);
+		libc.tls_align * 2,
+	libc.tls_align);
 }
 
 /* Stage 1 of the dynamic linker is defined in dlstart.c. It calls the

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -1670,12 +1670,14 @@ hidden void *__tls_get_new(tls_mod_off_t *v)
 static void update_tls_size()
 {
 
-if (!sgxlkl_in_sw_debug_mode()) {
-	static int fsgsbase_warn = 0;
-	if (!libc.user_tls_enabled && tls_cnt > 0 && !fsgsbase_warn) {
-		fprintf(stderr, "[    SGX-LKL   ] Warning: The application requires thread-local storage (TLS), but the current system configuration does not allow SGX-LKL to provide full TLS support in hardware mode. See sgx-lkl-run-oe --help-tls for more information.\n");
-		fsgsbase_warn = 1;
+	if (!sgxlkl_in_sw_debug_mode()) {
+		static int fsgsbase_warn = 0;
+		if (!libc.user_tls_enabled && tls_cnt > 0 && !fsgsbase_warn) {
+			fprintf(stderr, "[    SGX-LKL   ] Warning: The application requires thread-local storage (TLS), but the current system configuration does not allow SGX-LKL to provide full TLS support in hardware mode. See sgx-lkl-run-oe --help-tls for more information.\n");
+			fsgsbase_warn = 1;
+		}
 	}
+	
 	libc.tls_cnt = tls_cnt;
 	libc.tls_align = tls_align;
 	libc.tls_size = ALIGN(
@@ -1685,7 +1687,6 @@ if (!sgxlkl_in_sw_debug_mode()) {
 		libc.tls_align * 2,
 	libc.tls_align);
 }
-
 /* Stage 1 of the dynamic linker is defined in dlstart.c. It calls the
  * following stage 2 and stage 3 functions via primitive symbolic lookup
  * since it does not have access to their addresses to begin with. */
@@ -1772,9 +1773,9 @@ void *__dls2b(size_t *sp)
 	 * thread pointer at runtime. */
 	libc.tls_size = sizeof builtin_tls;
 	libc.tls_align = tls_align;
-	if (__init_tp(__copy_tls((void *)builtin_tls)) < 0) {
-		a_crash();
-	}
+	// if (__init_tp(__copy_tls((void *)builtin_tls)) < 0) {
+	// 	a_crash();
+	// }
 
 	// We don't call __dls3 here. Once we've got here, we're safe enough to
 	// init LKL, after which we can then run stage 3.

--- a/src/aio/aio.c
+++ b/src/aio/aio.c
@@ -183,7 +183,7 @@ static void cleanup(void *ctx)
 		__syscall(SYS_rt_sigqueueinfo, si.si_pid, si.si_signo, &si);
 	}
 	if (sev.sigev_notify == SIGEV_THREAD) {
-		//a_store(&__pthread_self()->cancel, 0);
+		a_store(&__pthread_self()->cancel, 0);
 		sev.sigev_notify_function(sev.sigev_value);
 	}
 }

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -14,17 +14,11 @@ int __init_tp(void *p)
 {
 	pthread_t td = p;
 	td->self = td;
-	if (sgxlkl_enclave->mode == SW_DEBUG_MODE)
+
+	if (sgxlkl_in_sw_debug_mode())
 	{
-		if (sgxlkl_in_sw_debug_mode())
-		{
-			int r = __set_thread_area(TP_ADJ(p));
-			if (r < 0)
-			{
-				sgxlkl_fail("Could not set thread area %p: %s\n", p, strerror(errno));
-			}
-		}
-		else
+		int r = __set_thread_area(TP_ADJ(p));
+		if (r < 0)
 		{
 			sgxlkl_fail("Could not set thread area %p: %s\n", p, strerror(errno));
 		}

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -8,20 +8,13 @@
 #include "atomic.h"
 #include "syscall.h"
 
-static int enclave_in_hw_mode(){
-	size_t i, *auxv;
-	auxv = libc.auxv;
-	for (i=0; auxv[i]; i+=2) if (auxv[i] == AT_HW_MODE) return auxv[i+1];
-	// crash out if we can't parse AT_HW_MODE from libc.auxv on stack
-	a_crash();
-	return -1;
-}
+
 int __init_tp(void *p)
 {
 	pthread_t td = p;
 	td->self = td;
 
-	if (enclave_in_hw_mode())
+	if (__is_enclave_in_hw_mode)
 	{
 		__asm__ volatile("wrfsbase %0" ::"r"(p));
 	}

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -18,10 +18,7 @@ int __init_tp(void *p)
 	if (sgxlkl_in_sw_debug_mode())
 	{
 		int r = __set_thread_area(TP_ADJ(p));
-		if (r < 0)
-		{
-			sgxlkl_fail("Could not set thread area %p: %s\n", p, strerror(errno));
-		}
+		if (r < 0) return -1;
 	}
 	else
 	{

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -7,22 +7,28 @@
 #include "libc.h"
 #include "atomic.h"
 #include "syscall.h"
-#include <enclave/enclave_oe.h>
-#include <enclave/enclave_util.h>
 
+static int enclave_in_hw_mode(){
+	size_t i, *auxv;
+	auxv = libc.auxv;
+	for (i=0; auxv[i]; i+=2) if (auxv[i] == AT_HW_MODE) return auxv[i+1];
+	// crash out if we can't parse AT_HW_MODE from libc.auxv on stack
+	a_crash();
+	return -1;
+}
 int __init_tp(void *p)
 {
 	pthread_t td = p;
 	td->self = td;
 
-	if (sgxlkl_in_sw_debug_mode())
+	if (enclave_in_hw_mode())
 	{
-		int r = __set_thread_area(TP_ADJ(p));
-		if (r < 0) return -1;
+		__asm__ volatile("wrfsbase %0" ::"r"(p));
 	}
 	else
 	{
-		__asm__ volatile("wrfsbase %0" ::"r"(p));
+		int r = __set_thread_area(TP_ADJ(p));
+		if (r < 0) return -1;
 	}
 	//int r = __set_thread_area(TP_ADJ(p));
 	//if (r < 0) return -1;

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -7,36 +7,14 @@
 #include "libc.h"
 #include "atomic.h"
 #include "syscall.h"
-#include "enclave/enclave_oe.h"
-#include "enclave/lthread.h"
-#include "enclave/enclave_util.h"
-
-static int spawned_ethreads = 1;
-
-struct pthread
-{
-};
+#include <enclave/enclave_oe.h>
+#include <enclave/enclave_util.h>
 
 int __init_tp(void *p)
 {
-	struct schedctx *td = p;
-
+	pthread_t td = p;
 	td->self = td;
-	// Prevent collisions with lthread TIDs which are assigned to newly spawned
-	// lthreads incrementally, starting from one.
-	td->tid = INT_MAX - a_fetch_add(&spawned_ethreads, 1);
-	td->locale = &libc.global_locale;
-	td->robust_list.head = &td->robust_list.head;
-	libc.can_do_threads = 1;
-	return 0;
-}
-
-int __init_utp(void *p, int set_tp)
-{
-	struct lthread_tcb_base *tcb = (struct lthread_tcb_base *)p;
-	tcb->self = p;
-	tcb->schedctx = __scheduler_self();
-	if (libc.user_tls_enabled && set_tp)
+	if (sgxlkl_enclave->mode == SW_DEBUG_MODE)
 	{
 		if (sgxlkl_in_sw_debug_mode())
 		{
@@ -48,70 +26,143 @@ int __init_utp(void *p, int set_tp)
 		}
 		else
 		{
-			__asm__ volatile("wrfsbase %0" ::"r"(p));
+			sgxlkl_fail("Could not set thread area %p: %s\n", p, strerror(errno));
 		}
 	}
+	else
+	{
+		__asm__ volatile("wrfsbase %0" ::"r"(p));
+	}
+	//int r = __set_thread_area(TP_ADJ(p));
+	//if (r < 0) return -1;
+	// if (!r) 
+	libc.can_do_threads = 1;
+	td->detach_state = DT_JOINABLE;
+	td->tid = __syscall(SYS_set_tid_address, &td->detach_state);
+	td->locale = &libc.global_locale;
+	td->robust_list.head = &td->robust_list.head;
 	return 0;
 }
 
-static struct builtin_tls
-{
+static struct builtin_tls {
 	char c;
-	struct schedctx *pt;
+	struct pthread pt;
 	void *space[16];
 } builtin_tls[1];
 #define MIN_TLS_ALIGN offsetof(struct builtin_tls, pt)
 
 static struct tls_module main_tls;
 
-/* Set up user-level thread TLS */
-void *__copy_utls(struct lthread *lt, unsigned char *mem, size_t sz)
+void *__copy_tls(unsigned char *mem)
 {
+	pthread_t td;
 	struct tls_module *p;
 	size_t i;
 	uintptr_t *dtv;
 
+#ifdef TLS_ABOVE_TP
+	dtv = (uintptr_t*)(mem + libc.tls_size) - (libc.tls_cnt + 1);
+
+	mem += -((uintptr_t)mem + sizeof(struct pthread)) & (libc.tls_align-1);
+	td = (pthread_t)mem;
+	mem += sizeof(struct pthread);
+
+	for (i=1, p=libc.tls_head; p; i++, p=p->next) {
+		dtv[i] = (uintptr_t)(mem + p->offset) + DTP_OFFSET;
+		memcpy(mem + p->offset, p->image, p->len);
+	}
+#else
 	dtv = (uintptr_t *)mem;
 
-	mem += sz - sizeof(struct lthread_tcb_base);
-	mem -= (uintptr_t)mem & (libc.tls_align - 1);
+	mem += libc.tls_size - sizeof(struct pthread);
+	mem -= (uintptr_t)mem & (libc.tls_align-1);
+	td = (pthread_t)mem;
 
-	for (i = 1, p = libc.tls_head; p; i++, p = p->next)
-	{
+	for (i=1, p=libc.tls_head; p; i++, p=p->next) {
 		dtv[i] = (uintptr_t)(mem - p->offset) + DTP_OFFSET;
 		memcpy(mem - p->offset, p->image, p->len);
 	}
+#endif
 	dtv[0] = libc.tls_cnt;
-	lt->dtv = lt->dtv_copy = dtv;
-	return (void *)mem;
+	td->dtv = td->dtv_copy = dtv;
+	return td;
 }
 
-/* Initialisation of user-level thread TLS image */
-void __init_utls(struct tls_module *apptls)
+#if ULONG_MAX == 0xffffffff
+typedef Elf32_Phdr Phdr;
+#else
+typedef Elf64_Phdr Phdr;
+#endif
+
+extern weak hidden const size_t _DYNAMIC[];
+
+static void static_init_tls(size_t *aux)
 {
-	if (apptls && apptls->image)
-	{
-		main_tls = *apptls;
+	unsigned char *p;
+	size_t n;
+	Phdr *phdr, *tls_phdr=0;
+	size_t base = 0;
+	void *mem;
+
+	for (p=(void *)aux[AT_PHDR],n=aux[AT_PHNUM]; n; n--,p+=aux[AT_PHENT]) {
+		phdr = (void *)p;
+		if (phdr->p_type == PT_PHDR)
+			base = aux[AT_PHDR] - phdr->p_vaddr;
+		if (phdr->p_type == PT_DYNAMIC && _DYNAMIC)
+			base = (size_t)_DYNAMIC - phdr->p_vaddr;
+		if (phdr->p_type == PT_TLS)
+			tls_phdr = phdr;
+		if (phdr->p_type == PT_GNU_STACK &&
+		    phdr->p_memsz > __default_stacksize)
+			__default_stacksize =
+				phdr->p_memsz < DEFAULT_STACK_MAX ?
+				phdr->p_memsz : DEFAULT_STACK_MAX;
+	}
+
+	if (tls_phdr) {
+		main_tls.image = (void *)(base + tls_phdr->p_vaddr);
+		main_tls.len = tls_phdr->p_filesz;
+		main_tls.size = tls_phdr->p_memsz;
+		main_tls.align = tls_phdr->p_align;
 		libc.tls_cnt = 1;
 		libc.tls_head = &main_tls;
 	}
 
-	main_tls.size += (-main_tls.size - (uintptr_t)main_tls.image) & (main_tls.align - 1);
+	main_tls.size += (-main_tls.size - (uintptr_t)main_tls.image)
+		& (main_tls.align-1);
+#ifdef TLS_ABOVE_TP
+	main_tls.offset = GAP_ABOVE_TP;
+	main_tls.offset += -GAP_ABOVE_TP & (main_tls.align-1);
+#else
 	main_tls.offset = main_tls.size;
-	if (main_tls.align < MIN_TLS_ALIGN)
-		main_tls.align = MIN_TLS_ALIGN;
+#endif
+	if (main_tls.align < MIN_TLS_ALIGN) main_tls.align = MIN_TLS_ALIGN;
 
 	libc.tls_align = main_tls.align;
-	libc.tls_size = 2 * sizeof(void *) + sizeof(struct lthread_tcb_base) + main_tls.size + main_tls.align + MIN_TLS_ALIGN - 1 & -MIN_TLS_ALIGN;
-}
+	libc.tls_size = 2*sizeof(void *) + sizeof(struct pthread)
+#ifdef TLS_ABOVE_TP
+		+ main_tls.offset
+#endif
+		+ main_tls.size + main_tls.align
+		+ MIN_TLS_ALIGN-1 & -MIN_TLS_ALIGN;
 
-/* Initialisation of ethread/scheduler TLS */
-static void static_init_tls()
-{
-	void *mem = __scheduler_self();
+	if (libc.tls_size > sizeof builtin_tls) {
+#ifndef SYS_mmap2
+#define SYS_mmap2 SYS_mmap
+#endif
+		mem = (void *)__syscall(
+			SYS_mmap2,
+			0, libc.tls_size, PROT_READ|PROT_WRITE,
+			MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		/* -4095...-1 cast to void * will crash on dereference anyway,
+		 * so don't bloat the init code checking for error codes and
+		 * explicitly calling a_crash(). */
+	} else {
+		mem = builtin_tls;
+	}
 
 	/* Failure to initialize thread pointer is always fatal. */
-	if (__init_tp(mem) < 0)
+	if (__init_tp(__copy_tls(mem)) < 0)
 		a_crash();
 }
 

--- a/src/env/__libc_start_main.c
+++ b/src/env/__libc_start_main.c
@@ -25,12 +25,18 @@ struct timespec sgxlkl_app_starttime;
 #ifdef __GNUC__
 __attribute__((__noinline__))
 #endif
+
+void __init_heap_from_libc()
+{
+	uint64_t *buf = malloc(8);
+}
+
 void __init_libc(char **envp, char *pn)
 {
-    size_t i, *auxv, aux[AUX_CNT] = { 0 };
-    __environ = envp;
-    for (i=0; envp[i]; i++);
-    libc.auxv = auxv = (void *)(envp+i+1);
+	size_t i, *auxv, aux[AUX_CNT] = { 0 };
+	__environ = envp;
+	for (i=0; envp[i]; i++);
+	libc.auxv = auxv = (void *)(envp+i+1);
 	for (i=0; auxv[i]; i+=2) if (auxv[i]<AUX_CNT) aux[auxv[i]] = auxv[i+1];
 	__hwcap = aux[AT_HWCAP];
 	__sysinfo = aux[AT_SYSINFO];

--- a/src/env/__libc_start_main.c
+++ b/src/env/__libc_start_main.c
@@ -25,64 +25,12 @@ struct timespec sgxlkl_app_starttime;
 #ifdef __GNUC__
 __attribute__((__noinline__))
 #endif
-
-static size_t *
-init_aux(size_t *auxv_base, char *pn)
-{
-    size_t i, aux_base[AUX_CNT] = {0};
-    for (i = 0; auxv_base[i]; i += 2)
-        if (auxv_base[i] < AUX_CNT)
-            aux_base[auxv_base[i]] = auxv_base[i + 1];
-
-    // By default auxv[AT_RANDOM] points to a buffer with 16 random bytes.
-    uint64_t *rbuf = malloc(16);
-    // TODO Use intrinsics
-    // if (!_rdrand64_step(&rbuf[0]))
-    //    goto err;
-    register uint64_t rd;
-    __asm__ volatile("rdrand %0;"
-                     : "=r"(rd));
-    rbuf[0] = rd;
-    __asm__ volatile("rdrand %0;"
-                     : "=r"(rd));
-    rbuf[1] = rd;
-
-    size_t *auxv = malloc(24 * sizeof(*auxv));
-    memset(auxv, 0, 24 * sizeof(*auxv));
-    auxv[0] = AT_CLKTCK;
-    auxv[1] = 100;
-    auxv[2] = AT_EXECFN;
-    auxv[3] = (size_t) pn;
-    auxv[4] = AT_HWCAP;
-    auxv[5] = aux_base[AT_HWCAP];
-    auxv[6] = AT_EGID;
-    auxv[7] = 0;
-    auxv[8] = AT_EUID;
-    auxv[9] = 0;
-    auxv[10] = AT_GID;
-    auxv[11] = 0;
-    auxv[12] = AT_PAGESZ;
-    auxv[13] = aux_base[AT_PAGESZ];
-    auxv[14] = AT_PLATFORM;
-    auxv[15] = (size_t) "x86_64";
-    auxv[16] = AT_SECURE;
-    auxv[17] = 0;
-    auxv[18] = AT_UID;
-    auxv[19] = 0;
-    auxv[20] = AT_RANDOM;
-    auxv[21] = (size_t)rbuf;
-    auxv[22] = AT_NULL;
-    auxv[23] = 0;
-
-    return auxv;
-}
-
 void __init_libc(char **envp, char *pn)
 {
     size_t i, *auxv, aux[AUX_CNT] = { 0 };
     __environ = envp;
     for (i=0; envp[i]; i++);
-    libc.auxv = auxv = init_aux((void *)(envp + i + 1), pn);
+    libc.auxv = auxv = (void *)(envp+i+1);
 	for (i=0; auxv[i]; i+=2) if (auxv[i]<AUX_CNT) aux[auxv[i]] = auxv[i+1];
 	__hwcap = aux[AT_HWCAP];
 	__sysinfo = aux[AT_SYSINFO];
@@ -94,7 +42,6 @@ void __init_libc(char **envp, char *pn)
 	for (i=0; pn[i]; i++) if (pn[i]=='/') __progname = pn+i+1;
 
 	__init_tls(aux);
-    libc.can_do_threads = 1;
 	__init_ssp((void *)aux[AT_RANDOM]);
 
 	if (aux[AT_UID]==aux[AT_EUID] && aux[AT_GID]==aux[AT_EGID]
@@ -134,7 +81,7 @@ int __libc_start_main(int (*main)(int,char **,char **), int argc, char **argv)
 	/* External linkage, and explicit noinline attribute if available,
 	 * are used to prevent the stack frame used during init from
 	 * persisting for the entire process lifetime. */
-	//__init_libc(envp, argv[0]);
+	__init_libc(envp, argv[0]);
 
 	/* Barrier against hoisting application code or anything using ssp
 	 * or thread pointer prior to its initialization above. */

--- a/src/env/__libc_start_main.c
+++ b/src/env/__libc_start_main.c
@@ -94,6 +94,7 @@ void __init_libc(char **envp, char *pn)
 	for (i=0; pn[i]; i++) if (pn[i]=='/') __progname = pn+i+1;
 
 	__init_tls(aux);
+    libc.can_do_threads = 1;
 	__init_ssp((void *)aux[AT_RANDOM]);
 
 	if (aux[AT_UID]==aux[AT_EUID] && aux[AT_GID]==aux[AT_EGID]

--- a/src/env/__libc_start_main.c
+++ b/src/env/__libc_start_main.c
@@ -25,12 +25,6 @@ struct timespec sgxlkl_app_starttime;
 #ifdef __GNUC__
 __attribute__((__noinline__))
 #endif
-
-void __init_heap_from_libc()
-{
-	uint64_t *buf = malloc(8);
-}
-
 void __init_libc(char **envp, char *pn)
 {
 	size_t i, *auxv, aux[AUX_CNT] = { 0 };

--- a/src/env/__libc_start_main.c
+++ b/src/env/__libc_start_main.c
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <syscall.h>
+#include <atomic.h>
 #include <libc.h>
 #include <string.h>
 #include "shared/env.h"
@@ -78,93 +79,75 @@ init_aux(size_t *auxv_base, char *pn)
 
 void __init_libc(char **envp, char *pn)
 {
-    size_t i, *auxv, aux[AUX_CNT] = {0};
+    size_t i, *auxv, aux[AUX_CNT] = { 0 };
     __environ = envp;
-    for (i = 0; envp[i]; i++)
-        ;
+    for (i=0; envp[i]; i++);
     libc.auxv = auxv = init_aux((void *)(envp + i + 1), pn);
-    for (i = 0; auxv[i]; i += 2)
-        if (auxv[i] < AUX_CNT)
-            aux[auxv[i]] = auxv[i + 1];
-    __hwcap = aux[AT_HWCAP];
-    __sysinfo = aux[AT_SYSINFO];
-    libc.page_size = aux[AT_PAGESZ];
+	for (i=0; auxv[i]; i+=2) if (auxv[i]<AUX_CNT) aux[auxv[i]] = auxv[i+1];
+	__hwcap = aux[AT_HWCAP];
+	__sysinfo = aux[AT_SYSINFO];
+	libc.page_size = aux[AT_PAGESZ];
 
-    if (!pn)
-        pn = (void *)aux[AT_EXECFN];
-    if (!pn)
-        pn = "";
-    __progname = __progname_full = pn;
-    for (i = 0; pn[i]; i++)
-        if (pn[i] == '/')
-            __progname = pn + i + 1;
+	if (!pn) pn = (void*)aux[AT_EXECFN];
+	if (!pn) pn = "";
+	__progname = __progname_full = pn;
+	for (i=0; pn[i]; i++) if (pn[i]=='/') __progname = pn+i+1;
 
-    __init_ssp((void *)aux[AT_RANDOM]);
+	__init_tls(aux);
+	__init_ssp((void *)aux[AT_RANDOM]);
 
-    if (aux[AT_UID] == aux[AT_EUID] && aux[AT_GID] == aux[AT_EGID] && !aux[AT_SECURE])
-        return;
+	if (aux[AT_UID]==aux[AT_EUID] && aux[AT_GID]==aux[AT_EGID]
+		&& !aux[AT_SECURE]) return;
 
-    struct pollfd pfd[3] = {{.fd = 0}, {.fd = 1}, {.fd = 2}};
-    int r =
+	struct pollfd pfd[3] = { {.fd=0}, {.fd=1}, {.fd=2} };
+	int r =
 #ifdef SYS_poll
-        __syscall(SYS_poll, pfd, 3, 0);
+	__syscall(SYS_poll, pfd, 3, 0);
 #else
-        __syscall(SYS_ppoll, pfd, 3, &(struct timespec){0}, 0, _NSIG / 8);
+	__syscall(SYS_ppoll, pfd, 3, &(struct timespec){0}, 0, _NSIG/8);
 #endif
-    if (r < 0)
-        a_crash();
-    for (i = 0; i < 3; i++)
-        if (pfd[i].revents & POLLNVAL)
-            if (__sys_open("/dev/null", O_RDWR) < 0)
-                a_crash();
-    libc.secure = 1;
+	if (r<0) a_crash();
+	for (i=0; i<3; i++) if (pfd[i].revents&POLLNVAL)
+		if (__sys_open("/dev/null", O_RDWR)<0)
+			a_crash();
+	libc.secure = 1;
 }
 
 static void libc_start_init(void)
 {
-    _init();
-    uintptr_t a = (uintptr_t)&__init_array_start;
-    for (; a < (uintptr_t)&__init_array_end; a += sizeof(void (*)()))
-        (*(void (**)(void))a)();
+	_init();
+	uintptr_t a = (uintptr_t)&__init_array_start;
+	for (; a<(uintptr_t)&__init_array_end; a+=sizeof(void(*)()))
+		(*(void (**)(void))a)();
 }
 
 weak_alias(libc_start_init, __libc_start_init);
 
-typedef int lsm2_fn(int (*)(int, char **, char **), int, char **);
+typedef int lsm2_fn(int (*)(int,char **,char **), int, char **);
 static lsm2_fn libc_start_main_stage2;
 
-int __libc_start_main(int (*main)(int, char **, char **), int argc, char **argv)
+int __libc_start_main(int (*main)(int,char **,char **), int argc, char **argv)
 {
-    char **envp = argv + argc + 1;
+	char **envp = argv+argc+1;
 
-    /* External linkage, and explicit noinline attribute if available,
-     * are used to prevent the stack frame used during init from
-     * persisting for the entire process lifetime. */
-    // libc is already inited at this point, don't init it again.
-    //__init_libc(envp, argv[0]);
+	/* External linkage, and explicit noinline attribute if available,
+	 * are used to prevent the stack frame used during init from
+	 * persisting for the entire process lifetime. */
+	//__init_libc(envp, argv[0]);
 
-    /* Barrier against hoisting application code or anything using ssp
-     * or thread pointer prior to its initialization above. */
-    lsm2_fn *stage2 = libc_start_main_stage2;
-    __asm__(""
-            : "+r"(stage2)
-            :
-            : "memory");
-    return stage2(main, argc, argv);
+	/* Barrier against hoisting application code or anything using ssp
+	 * or thread pointer prior to its initialization above. */
+	lsm2_fn *stage2 = libc_start_main_stage2;
+	__asm__ ( "" : "+r"(stage2) : : "memory" );
+	return stage2(main, argc, argv);
 }
 
-static int libc_start_main_stage2(int (*main)(int, char **, char **), int argc, char **argv)
+static int libc_start_main_stage2(int (*main)(int,char **,char **), int argc, char **argv)
 {
-    char **envp = argv + argc + 1;
-    __libc_start_init();
+	char **envp = argv+argc+1;
+	__libc_start_init();
 
-    SGXLKL_VERBOSE("Calling app main: %s\n", argv[0]);
-
-    if (getenv_bool("SGXLKL_PRINT_APP_RUNTIME", 0))
-    {
-        clock_gettime(CLOCK_MONOTONIC, &sgxlkl_app_starttime);
-    }
-    /* Pass control to the application */
-    exit(main(argc, argv, envp));
-    return 0;
+	/* Pass control to the application */
+	exit(main(argc, argv, envp));
+	return 0;
 }

--- a/src/env/__reset_tls.c
+++ b/src/env/__reset_tls.c
@@ -4,7 +4,6 @@
 
 void __reset_tls()
 {
-        /*
 	pthread_t self = __pthread_self();
 	struct tls_module *p;
 	size_t i, n = self->dtv[0];
@@ -13,5 +12,4 @@ void __reset_tls()
 		memcpy(mem, p->image, p->len);
 		memset(mem+p->len, 0, p->size - p->len);
 	}
-        */
 }

--- a/src/errno/__errno_location.c
+++ b/src/errno/__errno_location.c
@@ -3,9 +3,7 @@
 
 int *__errno_location(void)
 {
-        struct schedctx *sch = __scheduler_self();
-        struct lthread *lt = sch->sched.current_lthread;
-        return lt ? &lt->err : &sch->errno_val;
+	return &__pthread_self()->errno_val;
 }
 
 weak_alias(__errno_location, ___errno_location);

--- a/src/internal/libc.c
+++ b/src/internal/libc.c
@@ -4,6 +4,7 @@ struct __libc __libc;
 
 size_t __hwcap;
 size_t __sysinfo;
+size_t __is_enclave_in_hw_mode;
 char *__progname=0, *__progname_full=0;
 
 weak_alias(__progname, program_invocation_short_name);

--- a/src/internal/libc.h
+++ b/src/internal/libc.h
@@ -54,9 +54,4 @@ extern hidden const char __libc_version[];
 hidden void __synccall(void (*)(void *), void *);
 hidden int __setxid(int, int, int, int);
 
-// tests/overlay seems to work only if 
-// enclave_mmap is invoked first from libc
-// This is a temporary mitigation and should be removed
-// once the issue is root caused and fixed.
-hidden void __init_heap_from_libc();
 #endif

--- a/src/internal/libc.h
+++ b/src/internal/libc.h
@@ -36,7 +36,6 @@ struct __libc {
 
 extern hidden struct __libc __libc;
 #define libc __libc
-
 hidden void __init_libc(char **, char *);
 hidden void __init_tls(size_t *);
 hidden void __init_ssp(void *);
@@ -55,4 +54,9 @@ extern hidden const char __libc_version[];
 hidden void __synccall(void (*)(void *), void *);
 hidden int __setxid(int, int, int, int);
 
+// tests/overlay seems to work only if 
+// enclave_mmap is invoked first from libc
+// This is a temporary mitigation and should be removed
+// once the issue is root caused and fixed.
+hidden void __init_heap_from_libc();
 #endif

--- a/src/internal/libc.h
+++ b/src/internal/libc.h
@@ -38,8 +38,7 @@ extern hidden struct __libc __libc;
 #define libc __libc
 
 hidden void __init_libc(char **, char *);
-hidden void __init_utls(struct tls_module *apptls);
-hidden void __init_tls(void);
+hidden void __init_tls(size_t *);
 hidden void __init_ssp(void *);
 hidden void __libc_start_init(void);
 hidden void __funcs_on_exit(void);

--- a/src/internal/libc.h
+++ b/src/internal/libc.h
@@ -47,6 +47,7 @@ hidden void __fork_handler(int);
 
 extern hidden size_t __hwcap;
 extern hidden size_t __sysinfo;
+extern hidden size_t __is_enclave_in_hw_mode;
 extern char *__progname, *__progname_full;
 
 extern hidden const char __libc_version[];

--- a/src/internal/locale_impl.h
+++ b/src/internal/locale_impl.h
@@ -4,7 +4,7 @@
 #include <locale.h>
 #include <stdlib.h>
 #include "libc.h"
-#include "enclave/lthread_int.h"
+#include "pthread_impl.h"
 
 #define LOCALE_NAME_MAX 23
 
@@ -35,11 +35,9 @@ hidden char *__gettextdomain(void);
 #define C_LOCALE ((locale_t)&__c_locale)
 #define UTF8_LOCALE ((locale_t)&__c_dot_utf8_locale)
 
-extern struct lthread *lthread_self();
+#define CURRENT_LOCALE (__pthread_self()->locale)
 
-#define CURRENT_LOCALE (lthread_self()->locale)
-
-#define CURRENT_UTF8 (!!(lthread_self()->locale->cat[LC_CTYPE]))
+#define CURRENT_UTF8 (!!__pthread_self()->locale->cat[LC_CTYPE])
 
 #undef MB_CUR_MAX
 #define MB_CUR_MAX (CURRENT_UTF8 ? 4 : 1)

--- a/src/internal/stdio_impl.h
+++ b/src/internal/stdio_impl.h
@@ -3,7 +3,6 @@
 
 #include <stdio.h>
 #include "syscall.h"
-#include "enclave/lthread.h"
 
 #define UNGET 8
 
@@ -89,9 +88,9 @@ hidden FILE **__ofl_lock(void);
 hidden void __ofl_unlock(void);
 
 struct __pthread;
-hidden void __register_locked_file(FILE *f, struct lthread *self);
+hidden void __register_locked_file(FILE *, struct __pthread *);
 hidden void __unlist_locked_file(FILE *);
-hidden void __do_orphaned_stdio_locks(struct lthread *lt);
+hidden void __do_orphaned_stdio_locks(void);
 
 #define MAYBE_WAITERS 0x40000000
 

--- a/src/internal/syscall.h
+++ b/src/internal/syscall.h
@@ -1,8 +1,9 @@
 #ifndef _INTERNAL_SYSCALL_H
 #define _INTERNAL_SYSCALL_H
 
+#include <errno.h>
 #include <features.h>
-#include <enclave/lthread.h>
+//#include <enclave/lthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <sys/syscall.h>
@@ -41,14 +42,14 @@ hidden long __syscall_ret(unsigned long), __syscall(syscall_arg_t, ...),
 static inline long __filter_syscall0(long n) {
 
 	long params[6] = {0};
-	if (n == SYS_gettid) {
-		long res = (long)lthread_id();
-		__sgxlkl_log_syscall(SGXLKL_INTERNAL_SYSCALL, n, res, 0);
-		return res;
-	} else {
+	// if (n == SYS_gettid) {
+	// 	long res = (long)lthread_id();
+	// 	__sgxlkl_log_syscall(SGXLKL_INTERNAL_SYSCALL, n, res, 0);
+	// 	return res;
+	// } else {
 		long res = lkl_syscall(n, params);
 		return res;
-	}
+	//}
 }
 
 static inline long __filter_syscall1(long n, long a1) {

--- a/src/internal/syscall.h
+++ b/src/internal/syscall.h
@@ -3,7 +3,6 @@
 
 #include <errno.h>
 #include <features.h>
-//#include <enclave/lthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <sys/syscall.h>
@@ -42,14 +41,8 @@ hidden long __syscall_ret(unsigned long), __syscall(syscall_arg_t, ...),
 static inline long __filter_syscall0(long n) {
 
 	long params[6] = {0};
-	// if (n == SYS_gettid) {
-	// 	long res = (long)lthread_id();
-	// 	__sgxlkl_log_syscall(SGXLKL_INTERNAL_SYSCALL, n, res, 0);
-	// 	return res;
-	// } else {
-		long res = lkl_syscall(n, params);
-		return res;
-	//}
+	long res = lkl_syscall(n, params);
+	return res;
 }
 
 static inline long __filter_syscall1(long n, long a1) {

--- a/src/misc/syscall.c
+++ b/src/misc/syscall.c
@@ -6,8 +6,6 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include "enclave/enclave_util.h"
-
 #undef syscall
 
 /*

--- a/src/misc/syscall.c
+++ b/src/misc/syscall.c
@@ -4,6 +4,7 @@
 #include "syscall.h"
 #include <stdarg.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #include "enclave/enclave_util.h"
 

--- a/src/sched/affinity.c
+++ b/src/sched/affinity.c
@@ -2,6 +2,7 @@
 #include <sched.h>
 #include <string.h>
 #include <errno.h>
+#include "pthread_impl.h"
 
 #include "syscall.h"
 
@@ -13,8 +14,8 @@ int sched_setaffinity(pid_t tid, size_t size, const cpu_set_t *set)
 
 int pthread_setaffinity_np(pthread_t td, size_t size, const cpu_set_t *set)
 {
-	struct lthread *lt = (struct lthread *)td;
-	lt->attr.state |= BIT(LT_ST_PINNED);
+	// struct lthread *lt = (struct lthread *)td;
+	// lt->attr.state |= BIT(LT_ST_PINNED);
 	/* Don't call sched_setaffinity because ethreads are
 	   already pinned to cores in the starter */
 	return 0;

--- a/src/sched/sched_yield.c
+++ b/src/sched/sched_yield.c
@@ -1,18 +1,7 @@
 #include <sched.h>
-#include <enclave/lthread.h>
-#include "enclave/lthread_int.h"
 #include "syscall.h"
 
 int sched_yield()
 {
-        /* 
-         * lthread_yield does not add the current thread to the end of scheduler
-         * queue. We have to enqueue this thread after entering the scheduler
-         * because otherwise there is a chance of a race condition -- Another
-         * scheduler might pick up this lthread while the current scheduler is
-         * still executing it.
-         */
-        struct lthread *lt = lthread_self();
-        _lthread_yield_cb(lt, (void *)__scheduler_enqueue, lt);
-	return 0;
+	return syscall(SYS_sched_yield);
 }

--- a/src/signal/sigaction.c
+++ b/src/signal/sigaction.c
@@ -58,7 +58,6 @@ int __libc_sigaction(int sig, const struct sigaction *restrict sa, struct sigact
 			__block_all_sigs(&set);
 			LOCK(__abort_lock);
 		}
-
 		ksa.handler = sa->sa_handler;
 		ksa.flags = sa->sa_flags | SA_RESTORER;
 		ksa.restorer = (sa->sa_flags & SA_SIGINFO) ? __restore_rt : __restore;

--- a/src/stdio/__lockfile.c
+++ b/src/stdio/__lockfile.c
@@ -3,14 +3,7 @@
 
 int __lockfile(FILE *f)
 {
-	int owner = f->lock, tid;
-
-	if(__pthread_self()) {
-		tid  = __pthread_self()->tid;
-	} else {
-		tid = __scheduler_self()->tid;
-	}
-
+	int owner = f->lock, tid = __pthread_self()->tid;
 	if ((owner & ~MAYBE_WAITERS) == tid)
 		return 0;
 	owner = a_cas(&f->lock, 0, tid);

--- a/src/stdio/ftrylockfile.c
+++ b/src/stdio/ftrylockfile.c
@@ -2,10 +2,10 @@
 #include "pthread_impl.h"
 #include <limits.h>
 
-void __do_orphaned_stdio_locks(struct lthread *lt)
+void __do_orphaned_stdio_locks()
 {
 	FILE *f;
-	for (f=lt->stdio_locks; f; f=f->next_locked)
+	for (f=__pthread_self()->stdio_locks; f; f=f->next_locked)
 		a_store(&f->lock, 0x40000000);
 }
 
@@ -18,7 +18,7 @@ void __unlist_locked_file(FILE *f)
 	}
 }
 
-void __register_locked_file(FILE *f, struct lthread *self)
+void __register_locked_file(FILE *f, pthread_t self)
 {
 	f->lockcount = 1;
 	f->prev_locked = 0;

--- a/src/thread/__timedwait.c
+++ b/src/thread/__timedwait.c
@@ -28,8 +28,8 @@ int __timedwait_cp(volatile int *addr, int val,
 		top = &to;
 	}
 
-	r = -__syscall_cp(SYS_futex, addr, FUTEX_WAIT|priv, val, top,0,0);
-	if (r == ENOSYS) r = -__syscall_cp(SYS_futex, addr, FUTEX_WAIT, val, top,0,0);
+	r = -__syscall_cp(SYS_futex, addr, FUTEX_WAIT|priv, val, top);
+	if (r == ENOSYS) r = -__syscall_cp(SYS_futex, addr, FUTEX_WAIT, val, top);
 	if (r != EINTR && r != ETIMEDOUT && r != ECANCELED) r = 0;
 	/* Mitigate bug in old kernels wrongly reporting EINTR for non-
 	 * interrupting (SA_RESTART) signal handlers. This is only practical

--- a/src/thread/__tls_get_addr.c
+++ b/src/thread/__tls_get_addr.c
@@ -3,7 +3,7 @@
 
 void *__tls_get_addr(tls_mod_off_t *v)
 {
-	struct lthread *self = lthread_self();
+	pthread_t self = __pthread_self();
 	if (v[0] <= self->dtv[0])
 		return (void *)(self->dtv[v[0]] + v[1]);
 	return __tls_get_new(v);

--- a/src/thread/__wait.c
+++ b/src/thread/__wait.c
@@ -2,22 +2,16 @@
 
 void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 {
-        int spins=100;
-        if (priv) priv = FUTEX_PRIVATE;
-        while (spins-- && (!waiters || !*waiters)) {
-                if (*addr==val) a_spin();
-                else return;
-        }
-        if (waiters) a_inc(waiters);
-        while (*addr==val) {
-                // Continue to spin of we are in the scheduling context (no
-                // active lthread)
-                if (!pthread_self()) {
-                        a_spin();
-                } else {
-                        __syscall(SYS_futex, addr, FUTEX_WAIT|priv, val, 0, 0, 0) != -ENOSYS
-                        || __syscall(SYS_futex, addr, FUTEX_WAIT, val, 0, 0, 0);
-                }
-        }
-        if (waiters) a_dec(waiters);
+	int spins=100;
+	if (priv) priv = FUTEX_PRIVATE;
+	while (spins-- && (!waiters || !*waiters)) {
+		if (*addr==val) a_spin();
+		else return;
+	}
+	if (waiters) a_inc(waiters);
+	while (*addr==val) {
+		__syscall(SYS_futex, addr, FUTEX_WAIT|priv, val, 0) != -ENOSYS
+		|| __syscall(SYS_futex, addr, FUTEX_WAIT, val, 0);
+	}
+	if (waiters) a_dec(waiters);
 }

--- a/src/thread/pthread_attr_setinheritsched.c
+++ b/src/thread/pthread_attr_setinheritsched.c
@@ -3,21 +3,21 @@
 
 hidden void *__start_sched(void *p)
 {
-//	struct start_sched_args *ssa = p;
-//	void *start_arg = ssa->start_arg;
-//	void *(*start_fn)(void *) = ssa->start_fn;
-//	pthread_t self = __pthread_self();
-//
-//	int ret = -__syscall(SYS_sched_setscheduler, self->tid,
-//		ssa->attr->_a_policy, &ssa->attr->_a_prio);
-//	if (!ret) __restore_sigs(&ssa->mask);
-//	a_store(&ssa->futex, ret);
-//	__wake(&ssa->futex, 1, 1);
-//	if (ret) {
-//		self->detach_state = DT_DYNAMIC;
-//		return 0;
-//	}
-//	return start_fn(start_arg);
+	// struct start_sched_args *ssa = p;
+	// void *start_arg = ssa->start_arg;
+	// void *(*start_fn)(void *) = ssa->start_fn;
+	// pthread_t self = __pthread_self();
+
+	// int ret = -__syscall(SYS_sched_setscheduler, self->tid,
+	// 	ssa->attr->_a_policy, &ssa->attr->_a_prio);
+	// if (!ret) __restore_sigs(&ssa->mask);
+	// a_store(&ssa->futex, ret);
+	// __wake(&ssa->futex, 1, 1);
+	// if (ret) {
+	// 	self->detach_state = DT_DYNAMIC;
+	// 	return 0;
+	// }
+	// return start_fn(start_arg);
 	return ENOSYS;
 }
 

--- a/src/thread/pthread_barrier_wait.c
+++ b/src/thread/pthread_barrier_wait.c
@@ -84,8 +84,8 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 			a_spin();
 		a_inc(&inst->finished);
 		while (inst->finished == 1)
-			__syscall(SYS_futex,&inst->finished,FUTEX_WAIT|FUTEX_PRIVATE,1,0,0,0) != -ENOSYS
-                                || __syscall(SYS_futex,&inst->finished,FUTEX_WAIT,1,0,0,0);
+			__syscall(SYS_futex,&inst->finished,FUTEX_WAIT|FUTEX_PRIVATE,1,0) != -ENOSYS
+			|| __syscall(SYS_futex,&inst->finished,FUTEX_WAIT,1,0);
 		return PTHREAD_BARRIER_SERIAL_THREAD;
 	}
 

--- a/src/thread/pthread_cond_timedwait.c
+++ b/src/thread/pthread_cond_timedwait.c
@@ -49,8 +49,8 @@ static inline void unlock_requeue(volatile int *l, volatile int *r, int w)
 {
 	a_store(l, 0);
 	if (w) __wake(l, 1, 1);
-	else __syscall(SYS_futex, l, FUTEX_REQUEUE|FUTEX_PRIVATE, 0, 1, r, 0) != -ENOSYS
-                     || __syscall(SYS_futex, l, FUTEX_REQUEUE, 0, 1, r, 0);
+	else __syscall(SYS_futex, l, FUTEX_REQUEUE|FUTEX_PRIVATE, 0, 1, r) != -ENOSYS
+            || __syscall(SYS_futex, l, FUTEX_REQUEUE, 0, 1, r);
 }
 
 enum {

--- a/src/thread/pthread_detach.c
+++ b/src/thread/pthread_detach.c
@@ -3,7 +3,10 @@
 
 static int __pthread_detach(pthread_t t)
 {
-	lthread_detach2(t);
+	/* If the cas fails, detach state is either already-detached
+	 * or exiting/exited, and pthread_join will trap or cleanup. */
+	if (a_cas(&t->detach_state, DT_JOINABLE, DT_DYNAMIC) != DT_JOINABLE)
+		return __pthread_join(t, 0);
 	return 0;
 }
 

--- a/src/thread/pthread_getattr_np.c
+++ b/src/thread/pthread_getattr_np.c
@@ -2,6 +2,7 @@
 #include "pthread_impl.h"
 #include "libc.h"
 #include <sys/mman.h>
+#include <enclave/lthread.h>
 
 int pthread_getattr_np(pthread_t t, pthread_attr_t *a)
 {
@@ -12,13 +13,25 @@ int pthread_getattr_np(pthread_t t, pthread_attr_t *a)
 		a->_a_stackaddr = (uintptr_t)t->stack;
 		a->_a_stacksize = t->stack_size;
 	} else {
-		char *p = (void *)libc.auxv;
-		size_t l = PAGE_SIZE;
-		p += -(uintptr_t)p & PAGE_SIZE-1;
-		a->_a_stackaddr = (uintptr_t)p;
-		while (mremap(p-l-PAGE_SIZE, PAGE_SIZE, 2*PAGE_SIZE, 0)==MAP_FAILED && errno==ENOMEM)
-			l += PAGE_SIZE;
-		a->_a_stacksize = l;
+		/**
+		 * pthreads doesn't know about the stack of the main thread
+		 * and tries calculate the stackaddr relative to the aux vector
+		 * As currently the aux vector is not on the stack, the following
+		 * calculation is no longer correct.
+		*/
+		// char *p = (void *)libc.auxv;
+		// size_t l = PAGE_SIZE;
+		// p += -(uintptr_t)p & PAGE_SIZE-1;
+		// a->_a_stackaddr = (uintptr_t)p;
+		// while (mremap(p-l-PAGE_SIZE, PAGE_SIZE, 2*PAGE_SIZE, 0)==MAP_FAILED && errno==ENOMEM)
+		// 	l += PAGE_SIZE;
+		// a->_a_stacksize = l;
+		/**
+		 * As a temporary solution fetch stack address and size
+		 * from lthread. Remove when aux vector is properly setup.
+		 */
+		struct lthread* lt = lthread_current();
+		pthread_attr_setstack(a, lt->attr.stack, lt->attr.stack_size);
 	}
 	return 0;
 }

--- a/src/thread/pthread_getattr_np.c
+++ b/src/thread/pthread_getattr_np.c
@@ -5,8 +5,20 @@
 
 int pthread_getattr_np(pthread_t t, pthread_attr_t *a)
 {
-        pthread_attr_init(a);
-        pthread_attr_setdetachstate(a, t->attr.state & BIT(LT_ST_DETACH));
-        pthread_attr_setstack(a, t->attr.stack, t->attr.stack_size);
-        return 0;
+	*a = (pthread_attr_t){0};
+	a->_a_detach = t->detach_state>=DT_DETACHED;
+	a->_a_guardsize = t->guard_size;
+	if (t->stack) {
+		a->_a_stackaddr = (uintptr_t)t->stack;
+		a->_a_stacksize = t->stack_size;
+	} else {
+		char *p = (void *)libc.auxv;
+		size_t l = PAGE_SIZE;
+		p += -(uintptr_t)p & PAGE_SIZE-1;
+		a->_a_stackaddr = (uintptr_t)p;
+		while (mremap(p-l-PAGE_SIZE, PAGE_SIZE, 2*PAGE_SIZE, 0)==MAP_FAILED && errno==ENOMEM)
+			l += PAGE_SIZE;
+		a->_a_stacksize = l;
+	}
+	return 0;
 }

--- a/src/thread/pthread_getattr_np.c
+++ b/src/thread/pthread_getattr_np.c
@@ -2,7 +2,6 @@
 #include "pthread_impl.h"
 #include "libc.h"
 #include <sys/mman.h>
-#include <enclave/lthread.h>
 
 int pthread_getattr_np(pthread_t t, pthread_attr_t *a)
 {
@@ -13,25 +12,15 @@ int pthread_getattr_np(pthread_t t, pthread_attr_t *a)
 		a->_a_stackaddr = (uintptr_t)t->stack;
 		a->_a_stacksize = t->stack_size;
 	} else {
-		/**
-		 * pthreads doesn't know about the stack of the main thread
-		 * and tries calculate the stackaddr relative to the aux vector
-		 * As currently the aux vector is not on the stack, the following
-		 * calculation is no longer correct.
-		*/
-		// char *p = (void *)libc.auxv;
-		// size_t l = PAGE_SIZE;
-		// p += -(uintptr_t)p & PAGE_SIZE-1;
-		// a->_a_stackaddr = (uintptr_t)p;
+		char *p = (void *)libc.auxv;
+		size_t l = PAGE_SIZE;
+		p += -(uintptr_t)p & PAGE_SIZE-1;
+		a->_a_stackaddr = (uintptr_t)p;
+		// Main thread's stack currently is 512KB.
+		// The following code tries to remap it to double the size.
 		// while (mremap(p-l-PAGE_SIZE, PAGE_SIZE, 2*PAGE_SIZE, 0)==MAP_FAILED && errno==ENOMEM)
 		// 	l += PAGE_SIZE;
-		// a->_a_stacksize = l;
-		/**
-		 * As a temporary solution fetch stack address and size
-		 * from lthread. Remove when aux vector is properly setup.
-		 */
-		struct lthread* lt = lthread_current();
-		pthread_attr_setstack(a, lt->attr.stack, lt->attr.stack_size);
+		a->_a_stacksize = l;
 	}
 	return 0;
 }

--- a/src/thread/pthread_getspecific.c
+++ b/src/thread/pthread_getspecific.c
@@ -3,7 +3,8 @@
 
 static void *__pthread_getspecific(pthread_key_t k)
 {
-        return lthread_getspecific(k);
+	struct pthread *self = __pthread_self();
+	return self->tsd[k];
 }
 
 weak_alias(__pthread_getspecific, pthread_getspecific);

--- a/src/thread/pthread_join.c
+++ b/src/thread/pthread_join.c
@@ -1,12 +1,34 @@
 #include "pthread_impl.h"
 #include <sys/mman.h>
 
-int __pthread_join(pthread_t t, void **res)
+static int __pthread_timedjoin_np(pthread_t t, void **res, const struct timespec *at)
 {
-        if (t == 0) {
-                return ESRCH;
-        }
-        return lthread_join(t, res, WAIT_LIMITLESS);
+	int state, cs, r = 0;
+	__pthread_testcancel();
+	__pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	if (cs == PTHREAD_CANCEL_ENABLE) __pthread_setcancelstate(cs, 0);
+	while ((state = t->detach_state) && r != ETIMEDOUT && r != EINVAL) {
+		if (state >= DT_DETACHED) a_crash();
+		r = __timedwait_cp(&t->detach_state, state, CLOCK_REALTIME, at, 0);
+	}
+	__pthread_setcancelstate(cs, 0);
+	if (r == ETIMEDOUT || r == EINVAL) return r;
+	a_barrier();
+	if (res) *res = t->result;
+	if (t->map_base) __munmap(t->map_base, t->map_size);
+	return 0;
 }
 
+int __pthread_join(pthread_t t, void **res)
+{
+	return __pthread_timedjoin_np(t, res, 0);
+}
+
+static int __pthread_tryjoin_np(pthread_t t, void **res)
+{
+	return t->detach_state==DT_JOINABLE ? EBUSY : __pthread_join(t, res);
+}
+
+weak_alias(__pthread_tryjoin_np, pthread_tryjoin_np);
+weak_alias(__pthread_timedjoin_np, pthread_timedjoin_np);
 weak_alias(__pthread_join, pthread_join);

--- a/src/thread/pthread_key_create.c
+++ b/src/thread/pthread_key_create.c
@@ -1,8 +1,131 @@
 #include "pthread_impl.h"
 
+volatile size_t __pthread_tsd_size = sizeof(void *) * PTHREAD_KEYS_MAX;
+void *__pthread_tsd_main[PTHREAD_KEYS_MAX] = { 0 };
+
+static void (*keys[PTHREAD_KEYS_MAX])(void *);
+
+static pthread_rwlock_t key_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+static pthread_key_t next_key;
+
+static void nodtor(void *dummy)
+{
+}
+
+static void dirty(void *dummy)
+{
+}
+
+struct cleanup_args {
+	pthread_t caller;
+	int ret;
+};
+
+static void clean_dirty_tsd_callback(void *p)
+{
+	struct cleanup_args *args = p;
+	pthread_t self = __pthread_self();
+	pthread_key_t i;
+	for (i=0; i<PTHREAD_KEYS_MAX; i++) {
+		if (keys[i] == dirty && self->tsd[i])
+			self->tsd[i] = 0;
+	}
+	/* Arbitrary choice to avoid data race. */
+	if (args->caller == self) args->ret = 0;
+}
+
+static void dummy2(void (*f)(void *), void *p)
+{
+}
+
+weak_alias(dummy2, __pthread_key_delete_synccall);
+
+static int clean_dirty_tsd(void)
+{
+	struct cleanup_args args = {
+		.caller = __pthread_self(),
+		.ret = EAGAIN
+	};
+	__pthread_key_delete_synccall(clean_dirty_tsd_callback, &args);
+	return args.ret;
+}
+
 int __pthread_key_create(pthread_key_t *k, void (*dtor)(void *))
 {
-	return lthread_key_create(k, dtor);
+	pthread_key_t j = next_key;
+	pthread_t self = __pthread_self();
+	int found_dirty = 0;
+
+	/* This can only happen in the main thread before
+	 * pthread_create has been called. */
+	if (!self->tsd) self->tsd = __pthread_tsd_main;
+
+	/* Purely a sentinel value since null means slot is free. */
+	if (!dtor) dtor = nodtor;
+
+	pthread_rwlock_wrlock(&key_lock);
+	do {
+		if (!keys[j]) {
+			keys[next_key = *k = j] = dtor;
+			pthread_rwlock_unlock(&key_lock);
+			return 0;
+		} else if (keys[j] == dirty) {
+			found_dirty = 1;
+		}
+	} while ((j=(j+1)%PTHREAD_KEYS_MAX) != next_key);
+
+	/* It's possible that all slots are in use or __synccall fails. */
+	if (!found_dirty || clean_dirty_tsd()) {
+		pthread_rwlock_unlock(&key_lock);
+		return EAGAIN;
+	}
+
+	/* If this point is reached there is necessarily a newly-cleaned
+	 * slot to allocate to satisfy the caller's request. Find it and
+	 * mark any additional previously-dirty slots clean. */
+	for (j=0; j<PTHREAD_KEYS_MAX; j++) {
+		if (keys[j] == dirty) {
+			if (dtor) {
+				keys[next_key = *k = j] = dtor;
+				dtor = 0;
+			} else {
+				keys[j] = 0;
+			}
+		}
+	}
+
+	pthread_rwlock_unlock(&key_lock);
+	return 0;
+}
+
+int __pthread_key_delete_impl(pthread_key_t k)
+{
+	pthread_rwlock_wrlock(&key_lock);
+	keys[k] = dirty;
+	pthread_rwlock_unlock(&key_lock);
+	return 0;
+}
+
+void __pthread_tsd_run_dtors()
+{
+	pthread_t self = __pthread_self();
+	int i, j;
+	for (j=0; self->tsd_used && j<PTHREAD_DESTRUCTOR_ITERATIONS; j++) {
+		pthread_rwlock_rdlock(&key_lock);
+		self->tsd_used = 0;
+		for (i=0; i<PTHREAD_KEYS_MAX; i++) {
+			void *val = self->tsd[i];
+			void (*dtor)(void *) = keys[i];
+			self->tsd[i] = 0;
+			if (val && dtor && dtor != nodtor && dtor != dirty) {
+				pthread_rwlock_unlock(&key_lock);
+				dtor(val);
+				pthread_rwlock_rdlock(&key_lock);
+			}
+		}
+		pthread_rwlock_unlock(&key_lock);
+	}
 }
 
 weak_alias(__pthread_key_create, pthread_key_create);

--- a/src/thread/pthread_key_delete.c
+++ b/src/thread/pthread_key_delete.c
@@ -1,9 +1,14 @@
 #include "pthread_impl.h"
 #include "libc.h"
 
+void __pthread_key_delete_synccall(void (*f)(void *), void *p)
+{
+	__synccall(f, p);
+}
+
 int __pthread_key_delete(pthread_key_t k)
 {
-	return lthread_key_delete(k);
+	return __pthread_key_delete_impl(k);
 }
 
 weak_alias(__pthread_key_delete, pthread_key_delete);

--- a/src/thread/pthread_kill.c
+++ b/src/thread/pthread_kill.c
@@ -1,10 +1,12 @@
 #include "pthread_impl.h"
-#include "signal.h"
+#include "lock.h"
 
 int pthread_kill(pthread_t t, int sig)
 {
-	if(sig == SIGTERM || sig == SIGKILL) {
-		lthread_cancel(t);
-	}
-	return 0;
+	int r;
+	LOCK(t->killlock);
+	r = t->tid ? -__syscall(SYS_tkill, t->tid, sig)
+		: (sig+0U >= _NSIG ? EINVAL : 0);
+	UNLOCK(t->killlock);
+	return r;
 }

--- a/src/thread/pthread_self.c
+++ b/src/thread/pthread_self.c
@@ -3,7 +3,7 @@
 
 static pthread_t __pthread_self_internal()
 {
-	return lthread_self();
+	return __pthread_self();
 }
 
 weak_alias(__pthread_self_internal, pthread_self);

--- a/src/thread/pthread_setcancelstate.c
+++ b/src/thread/pthread_setcancelstate.c
@@ -1,9 +1,12 @@
-#include "enclave/lthread_int.h"
-#include <enclave/lthread.h>
+#include "pthread_impl.h"
 
 int __pthread_setcancelstate(int new, int *old)
 {
-    return lthread_setcancelstate(new, old);
+	if (new > 2U) return EINVAL;
+	struct pthread *self = __pthread_self();
+	if (old) *old = self->canceldisable;
+	self->canceldisable = new;
+	return 0;
 }
 
 weak_alias(__pthread_setcancelstate, pthread_setcancelstate);

--- a/src/thread/pthread_setcanceltype.c
+++ b/src/thread/pthread_setcanceltype.c
@@ -2,5 +2,10 @@
 
 int pthread_setcanceltype(int new, int *old)
 {
+	struct pthread *self = __pthread_self();
+	if (new > 1U) return EINVAL;
+	if (old) *old = self->cancelasync;
+	self->cancelasync = new;
+	if (new) pthread_testcancel();
 	return 0;
 }

--- a/src/thread/pthread_setspecific.c
+++ b/src/thread/pthread_setspecific.c
@@ -2,5 +2,11 @@
 
 int pthread_setspecific(pthread_key_t k, const void *x)
 {
-        return lthread_setspecific(k, x);
+	struct pthread *self = __pthread_self();
+	/* Avoid unnecessary COW */
+	if (self->tsd[k] != x) {
+		self->tsd[k] = (void *)x;
+		self->tsd_used = 1;
+	}
+	return 0;
 }

--- a/src/thread/synccall.c
+++ b/src/thread/synccall.c
@@ -35,7 +35,7 @@ static void handler(int sig)
 	while (a_cas_p(&head, ch.next, &ch) != ch.next);
 
 	if (a_cas(&target_tid, ch.tid, 0) == (ch.tid | 0x80000000))
-            __syscall(SYS_futex, &target_tid, FUTEX_UNLOCK_PI|FUTEX_PRIVATE, 0, 0, 0, 0);
+		__syscall(SYS_futex, &target_tid, FUTEX_UNLOCK_PI|FUTEX_PRIVATE);
 
 	sem_wait(&ch.target_sem);
 	callback(context);
@@ -137,7 +137,7 @@ void __synccall(void (*func)(void *), void *ctx)
 				ts.tv_nsec -= 1000000000;
 			}
 			r = -__syscall(SYS_futex, &target_tid,
-                                       FUTEX_LOCK_PI|FUTEX_PRIVATE, 0, &ts, 0, 0);
+				FUTEX_LOCK_PI|FUTEX_PRIVATE, 0, &ts);
 
 			/* Obtaining the lock means the thread responded. ESRCH
 			 * means the target thread exited, which is okay too. */

--- a/src/thread/tss_set.c
+++ b/src/thread/tss_set.c
@@ -3,5 +3,11 @@
 
 int tss_set(tss_t k, void *x)
 {
-	return lthread_setspecific(k, x) ? thrd_error : thrd_success;
+	struct pthread *self = __pthread_self();
+	/* Avoid unnecessary COW */
+	if (self->tsd[k] != x) {
+		self->tsd[k] = x;
+		self->tsd_used = 1;
+	}
+	return thrd_success;
 }

--- a/src/thread/x86_64/__set_thread_area.s
+++ b/src/thread/x86_64/__set_thread_area.s
@@ -4,8 +4,12 @@
 .hidden __set_thread_area
 .type __set_thread_area,@function
 __set_thread_area:
-	mov %rdi,%rsi           /* shift for syscall */
-	movl $0x1002,%edi       /* SET_FS register */
-	movl $158,%eax          /* set fs segment to */
-	syscall                 /* arch_prctl(SET_FS, arg)*/
+	subq $4*8, %rsp
+	push %rdi
+	push $0x1002            /* SET_FS register */
+	mov $167, %rdi          /* LKL's SYS_prctl */
+	call lkl_syscall@PLT    /* arch_prctl(SET_FS, arg)*/
+	add $6*8, %rsp
 	ret
+
+	.weak lkl_syscall

--- a/src/thread/x86_64/__set_thread_area.s
+++ b/src/thread/x86_64/__set_thread_area.s
@@ -4,12 +4,8 @@
 .hidden __set_thread_area
 .type __set_thread_area,@function
 __set_thread_area:
-	subq $4*8, %rsp
-	push %rdi
-	push $0x1002            /* SET_FS register */
-	mov $167, %rdi          /* LKL's SYS_prctl */
-	call lkl_syscall@PLT    /* arch_prctl(SET_FS, arg)*/
-	add $6*8, %rsp
+	mov %rdi,%rsi           /* shift for syscall */
+	movl $0x1002,%edi       /* SET_FS register */
+	movl $158,%eax          /* set fs segment to */
+	syscall                 /* arch_prctl(SET_FS, arg)*/
 	ret
-
-	.weak lkl_syscall

--- a/src/thread/x86_64/__unmapself.s
+++ b/src/thread/x86_64/__unmapself.s
@@ -3,7 +3,7 @@
 .global __unmapself
 .type   __unmapself,@function
 __unmapself:
-	subq $4*8, %rsp
+	subq $5*8, %rsp
 	push %rsi
 	push %rdi
 	mov %rsp, %rsi

--- a/src/thread/x86_64/__unmapself.s
+++ b/src/thread/x86_64/__unmapself.s
@@ -3,8 +3,20 @@
 .global __unmapself
 .type   __unmapself,@function
 __unmapself:
-	movl $11,%eax   /* SYS_munmap */
-	syscall         /* munmap(arg2,arg3) */
-	xor %rdi,%rdi   /* exit() args: always return success */
-	movl $60,%eax   /* SYS_exit */
-	syscall         /* exit(0) */
+	subq $4*8, %rsp
+	push %rsi
+	push %rdi
+	mov %rsp, %rsi
+	mov $215,%rdi   /* LKL's SYS_munmap */
+	call lkl_syscall@PLT         /* munmap(arg2,arg3) */
+	// exit system call if this function returns
+	subq $5*8, %rsp
+	xor %rax, %rax /* exit() args: always return success */
+	push %rax
+	mov %rsp, %rsi
+	mov $93, %rdi
+	call lkl_syscall@PLT
+	// Should be unreachable, trap if it is reached
+	ud2
+
+	.weak lkl_syscall

--- a/src/thread/x86_64/clone.s
+++ b/src/thread/x86_64/clone.s
@@ -40,6 +40,7 @@ __clone:
 	xor %ebp,%ebp
 	pop %rdi
 	pop %r9
+	and $-16,%rsp
 	call *%r9
 	// exit system call if this function returns
 	subq $5*8, %rsp

--- a/src/time/clock_gettime.c
+++ b/src/time/clock_gettime.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include "syscall.h"
 #include "atomic.h"
+#include "libc.h"
 
 #include <enclave/enclave_oe.h>
 

--- a/src/unistd/faccessat.c
+++ b/src/unistd/faccessat.c
@@ -1,7 +1,27 @@
 #include <unistd.h>
 #include <fcntl.h>
-#include <errno.h>
+#include <sys/wait.h>
 #include "syscall.h"
+#include "pthread_impl.h"
+
+struct ctx {
+	int fd;
+	const char *filename;
+	int amode;
+	int p;
+};
+
+static int checker(void *p)
+{
+	struct ctx *c = p;
+	int ret;
+	if (__syscall(SYS_setregid, __syscall(SYS_getegid), -1)
+	    || __syscall(SYS_setreuid, __syscall(SYS_geteuid), -1))
+		__syscall(SYS_exit, 1);
+	ret = __syscall(SYS_faccessat, c->fd, c->filename, c->amode, 0);
+	__syscall(SYS_write, c->p, &ret, sizeof ret);
+	return 0;
+}
 
 int faccessat(int fd, const char *filename, int amode, int flag)
 {
@@ -11,9 +31,26 @@ int faccessat(int fd, const char *filename, int amode, int flag)
 	if (flag != AT_EACCESS)
 		return __syscall_ret(-EINVAL);
 
-	int ret = -EBUSY;
+	char stack[1024];
+	sigset_t set;
+	pid_t pid;
+	int status;
+	int ret, p[2];
 
-        ret = __syscall(SYS_faccessat, fd, filename, amode, 0);
+	if (pipe2(p, O_CLOEXEC)) return __syscall_ret(-EBUSY);
+	struct ctx c = { .fd = fd, .filename = filename, .amode = amode, .p = p[1] };
+
+	__block_all_sigs(&set);
+	
+	pid = __clone(checker, stack+sizeof stack, 0, &c);
+	__syscall(SYS_close, p[1]);
+
+	if (pid<0 || __syscall(SYS_read, p[0], &ret, sizeof ret) != sizeof(ret))
+		ret = -EBUSY;
+	__syscall(SYS_close, p[0]);
+	__syscall(SYS_wait4, pid, &status, __WCLONE, 0);
+
+	__restore_sigs(&set);
 
 	return __syscall_ret(ret);
 }

--- a/src/unistd/setxid.c
+++ b/src/unistd/setxid.c
@@ -14,6 +14,7 @@ static void do_setxid(void *p)
 	struct ctx *c = p;
 	if (c->err>0) return;
 	int ret = -__syscall(c->nr, c->id, c->eid, c->sid);
+	//int ret = -__syscall(c->nr, c->id, c->eid, c->sid, 0, 0, 0);
 	if (ret && !c->err) {
 		/* If one thread fails to set ids after another has already
 		 * succeeded, forcibly killing the process is the only safe
@@ -30,7 +31,8 @@ int __setxid(int nr, int id, int eid, int sid)
 	/* err is initially nonzero so that failure of the first thread does not
 	 * trigger the safety kill above. */
 	struct ctx c = { .nr = nr, .id = id, .eid = eid, .sid = sid, .err = -1 };
-	__synccall(do_setxid, &c);
+	//__synccall(do_setxid, &c);
+	do_setxid(&c);
 	if (c.err) {
 		if (c.err>0) errno = c.err;
 		return -1;

--- a/src/unistd/setxid.c
+++ b/src/unistd/setxid.c
@@ -13,7 +13,7 @@ static void do_setxid(void *p)
 {
 	struct ctx *c = p;
 	if (c->err>0) return;
-	int ret = -__syscall(c->nr, c->id, c->eid, c->sid, 0, 0, 0);
+	int ret = -__syscall(c->nr, c->id, c->eid, c->sid);
 	if (ret && !c->err) {
 		/* If one thread fails to set ids after another has already
 		 * succeeded, forcibly killing the process is the only safe
@@ -30,7 +30,7 @@ int __setxid(int nr, int id, int eid, int sid)
 	/* err is initially nonzero so that failure of the first thread does not
 	 * trigger the safety kill above. */
 	struct ctx c = { .nr = nr, .id = id, .eid = eid, .sid = sid, .err = -1 };
-	do_setxid(&c);
+	__synccall(do_setxid, &c);
 	if (c.err) {
 		if (c.err>0) errno = c.err;
 		return -1;


### PR DESCRIPTION
### Summary
- Reverts most of pthread implementation back to upstream musl.
- Sets auxiliary vector entries at the top of stack before app entry.