### PR TITLE
Redirect epoll_wait to use epoll_pwait

### DIFF
--- a/src/misc/syscall.c
+++ b/src/misc/syscall.c
@@ -405,13 +405,13 @@ static long redirect_syscall(long n,
 		params_len = 2;
 		res = dup2(a, b);
 		break;
-    case 232 /* SYS_epoll_wait */:
-        // LKL does not support SYS_epoll_wait but it includes SYS_epoll_pwait, which can
+	case 232 /* SYS_epoll_wait */:
+		// LKL does not support SYS_epoll_wait but it includes SYS_epoll_pwait, which can
 		// be made to behave equivalently.
-        params_len = 4;
-        res = epoll_pwait(a, (struct epoll_event*)b, c, d, 0);
-        break;
-    default:
+		params_len = 4;
+		res = epoll_pwait(a, (struct epoll_event*)b, c, d, 0);
+		break;
+	default:
 		sgxlkl_warn("x86-64 syscall %d has no known mapping\n", n);
 	}
 

--- a/src/misc/syscall.c
+++ b/src/misc/syscall.c
@@ -1,5 +1,6 @@
 #define _BSD_SOURCE
 #include <unistd.h>
+#include <sys/epoll.h>
 #include "syscall.h"
 #include <stdarg.h>
 #include <assert.h>
@@ -404,7 +405,13 @@ static long redirect_syscall(long n,
 		params_len = 2;
 		res = dup2(a, b);
 		break;
-	default:
+    case 232 /* SYS_epoll_wait */:
+        // LKL does not support SYS_epoll_wait but it includes SYS_epoll_pwait, which can
+		// be made to behave equivalently.
+        params_len = 4;
+        res = epoll_pwait(a, (struct epoll_event*)b, c, d, 0);
+        break;
+    default:
 		sgxlkl_warn("x86-64 syscall %d has no known mapping\n", n);
 	}
 


### PR DESCRIPTION
Since the LKL syscalls do not include `epoll_wait`, this PR uses the redirection mechanism in musl to implement `epoll_wait` using `epoll_pwait`. This is needed to run certain versions of Node.JS (see https://github.com/lsds/sgx-lkl/pull/663).