### PR TITLE
Remove enclave_mmap usage from expand_heap

### DIFF
--- a/src/malloc/expand_heap.c
+++ b/src/malloc/expand_heap.c
@@ -66,7 +66,7 @@ void *__expand_heap(size_t *pn)
 
 	size_t min = (size_t)PAGE_SIZE << mmap_step/2;
 	if (n < min) n = min;
-	void *area = enclave_mmap(0, n, 0, PROT_READ|PROT_WRITE, 1);
+	void *area = mmap(0, n, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0);
 	if (((intptr_t)area) < 0) return 0;
 	*pn = n;
 	mmap_step++;


### PR DESCRIPTION
Per David, it is now believed that aren't using malloc before LKL
starts and should therefore be able to do mmap here.