### PR TITLE
Remove unnecessary #include

### DIFF
--- a/src/env/__libc_start_main.c
+++ b/src/env/__libc_start_main.c
@@ -8,7 +8,6 @@
 #include <atomic.h>
 #include <libc.h>
 #include <string.h>
-#include "shared/env.h"
 
 static void dummy(void) {}
 weak_alias(dummy, _init);


### PR DESCRIPTION
To go with the tracing config options/getenv removal in sgx-lkl, see https://github.com/lsds/sgx-lkl/pull/806.

Signed-off-by: Christoph M. Wintersteiger <cwinter@microsoft.com>