### PR TITLE
User-space separation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ lib/libsgxlkl.so: $(LOBJS) $(LDSO_OBJS) $(lkllib) $(sgxlkllib) $(sgxlkllibs) mus
 
 # Capture all MUSL objects in this file (included by ./user/Makefile)
 muslobjs:
-	echo "MUSL_OBJECTS = $(addprefix $(CURDIR)/,$(LOBJS) $(LDSO_OBJS))" > muslobjs.mak
+	@ echo "MUSL_OBJECTS = $(addprefix $(CURDIR)/,$(LOBJS) $(LDSO_OBJS))" > muslobjs.mak
 
 # Original OE linking options:
 #	-nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now 

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ obj/%.lo: $(srcdir)/%.c $(GENH) $(IMPH)
 
 # LDFLAGS_AUTO = -Wl,--sort-section,alignment -Wl,--sort-common -Wl,--gc-sections -Wl,--hash-style=both -Wl,--no-undefined -Wl,--exclude-libs=ALL -Wl,--dynamic-list=./dynamic.list
 
-lib/libsgxlkl.so: $(LOBJS) $(LDSO_OBJS) $(lkllib) $(sgxlkllib) $(sgxlkllibs)
+lib/libsgxlkl.so: $(LOBJS) $(LDSO_OBJS) $(lkllib) $(sgxlkllib) $(sgxlkllibs) muslobjs
 	@mkdir -p obj/sgxlkl
 	@echo "AR $@"
 	@cd obj/sgxlkl/; ar -x $(sgxlkllib)
@@ -184,6 +184,10 @@ lib/libsgxlkl.so: $(LOBJS) $(LDSO_OBJS) $(lkllib) $(sgxlkllib) $(sgxlkllibs)
 	-o $@ $(LOBJS) obj/sgxlkl/*.o ./libgcov_musl.a $(LDSO_OBJS) $(LIBCC) $(sgxlkllibs) $(lkllib) \
 	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now  \
 	-L$(OE_SDK_LIBS)/openenclave/enclave -loeenclave -loecryptombed -lmbedx509 -lmbedcrypto -loesyscall -loecore
+
+# Capture all MUSL objects in this file (included by ./user/Makefile)
+muslobjs:
+	echo "MUSL_OBJECTS = $(addprefix $(CURDIR)/,$(LOBJS) $(LDSO_OBJS))" > muslobjs.mak
 
 # Original OE linking options:
 #	-nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now 

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -688,7 +688,7 @@ static void __gdb_load_debug_symbols(int fd, struct dso *dso, Ehdr *eh)
 
 	char buf[30];
 	char linkname[PATH_MAX] = {0};
-
+	__gdb_load_debug_symbols_alive = 1;
 	if (!__gdb_load_debug_symbols_alive) return;
 
 	/* try to reverse-engineer the filename we're loading from */

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -652,15 +652,20 @@ static void unmap_library(struct dso *dso)
 	}
 }
 
-void __attribute__ ((noinline)) __gdb_hook_load_debug_symbols(struct dso *dso, void *symmem, ssize_t symsz)
+void __attribute__((noinline)) __attribute__((__weak__))
+__gdb_hook_load_debug_symbols_wrap(struct dso *dso, void *symmem, ssize_t symsz)
 {
-	__asm__ volatile ("" : : "m" (dso), "m" (symmem), "m" (symsz));
+    /* this is overriden in user space by sgx-lkl/src/user/enter.c */
+    sgxlkl_warn("*************** weak: %s\n", __FUNCTION__);
 }
 
-void __attribute__ ((noinline)) __gdb_hook_load_debug_symbols_from_file(struct dso *dso, char *libpath)
+void __attribute__((noinline)) __attribute__((__weak__))
+__gdb_hook_load_debug_symbols_from_file_wrap(struct dso *dso, char *libpath)
 {
-	__asm__ volatile ("" : : "m" (dso), "m" (libpath));
+    /* this is overriden in user space by sgx-lkl/src/user/enter.c */
+    sgxlkl_warn("*************** weak: %s\n", __FUNCTION__);
 }
+
 
 /* can't be static, we need to keep the symbol alive */
 int __gdb_load_debug_symbols_alive = 0;
@@ -823,7 +828,7 @@ foundpath:
 		size_t path_len = strlen(debugmount) + strlen(debugpath);
 		char debugmountpath[path_len + 1];
 		snprintf(debugmountpath, path_len + 1, "%s%s", debugmount, debugpath);
-		__gdb_hook_load_debug_symbols_from_file(dso, debugmountpath);
+		__gdb_hook_load_debug_symbols_from_file_wrap(dso, debugmountpath);
 	} else {
 		/* allocate memory for the symbols */
 		symmem = malloc(fdstat.st_size);
@@ -841,7 +846,7 @@ foundpath:
 		}
 
 		/* invoke gdb */
-		__gdb_hook_load_debug_symbols(dso, symmem, fdstat.st_size);
+		__gdb_hook_load_debug_symbols_wrap(dso, symmem, fdstat.st_size);
 	}
 
 fail:

--- a/ldso/dynlink.c
+++ b/ldso/dynlink.c
@@ -668,7 +668,7 @@ __gdb_hook_load_debug_symbols_from_file_wrap(struct dso *dso, char *libpath)
 
 
 /* can't be static, we need to keep the symbol alive */
-int __gdb_load_debug_symbols_alive = 0;
+int __gdb_get_load_debug_symbols_alive();
 
 /* sgx-lkl hooks for loading debug symbols */
 static void __gdb_load_debug_symbols(int fd, struct dso *dso, Ehdr *eh)
@@ -688,8 +688,7 @@ static void __gdb_load_debug_symbols(int fd, struct dso *dso, Ehdr *eh)
 
 	char buf[30];
 	char linkname[PATH_MAX] = {0};
-	__gdb_load_debug_symbols_alive = 1;
-	if (!__gdb_load_debug_symbols_alive) return;
+	if (!__gdb_get_load_debug_symbols_alive()) return;
 
 	/* try to reverse-engineer the filename we're loading from */
 	/* warning: this is racy! */


### PR DESCRIPTION
This PR (1) extends debugging to work with the SGX-LKL user-space separation work, and (2) generates a list of objects (**muslobjs.mak**) needed by **libsgxlkl-user.so**.