### PR TITLE
Revert "Remove no longer needed init_clock_res"

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -104,6 +104,10 @@ int clock_settime (clockid_t, const struct timespec *);
 int clock_nanosleep (clockid_t, int, const struct timespec *, struct timespec *);
 int clock_getcpuclockid (pid_t, clockid_t *);
 
+/* Used by SGX-LKL for providing clock resolutions at startup to make host call
+ * unnecessary. */
+void init_clock_res(struct timespec clock_res[]);
+
 struct sigevent;
 int timer_create (clockid_t, struct sigevent *__restrict, timer_t *__restrict);
 int timer_delete (timer_t);

--- a/src/time/clock_getres.c
+++ b/src/time/clock_getres.c
@@ -1,6 +1,28 @@
 #include <time.h>
+#include "syscall.h"
 
 /*
   CLOCK_REALTIME (1) to CLOCK_BOOTTIME (7)
 */
 #define CLOCK_RES_MAX CLOCK_BOOTTIME
+struct timespec host_clock_res[CLOCK_RES_MAX + 1];
+
+void init_clock_res(struct timespec clock_res[]) {
+	for (int i = 0; i <= CLOCK_RES_MAX; i++) {
+		host_clock_res[i] = clock_res[i];
+	}
+}
+
+int clock_getres(clockid_t clk, struct timespec *ts)
+{
+	/* Unsupported for now */
+	if (clk == CLOCK_PROCESS_CPUTIME_ID ||
+	    clk == CLOCK_THREAD_CPUTIME_ID)
+		return -1;
+
+	if (clk <= CLOCK_RES_MAX) {
+		*ts = host_clock_res[clk];
+		return 0;
+	}
+	return syscall(SYS_clock_getres, clk, ts);
+}


### PR DESCRIPTION
This reverts commit 1673c3e1b6f8fb162ce60bebcd7869ff1a0b1f04.

Somehow this passed CI and then started failing. Reverting for now.